### PR TITLE
Dev

### DIFF
--- a/octopus/src/main/scala/octopus/OctopusContext.scala
+++ b/octopus/src/main/scala/octopus/OctopusContext.scala
@@ -1,12 +1,14 @@
 package scala.octopus
 
+import java.util.concurrent.atomic.AtomicReference
+
 import main.scala.octopus.{TextDataSet, DataSet, DeployedDataSet}
 import org.apache.spark.SparkContext
 
 /**
  * Created by umizrahi on 25/02/2016.
  */
-class OctopusContext(sc: SparkContext) {
+class OctopusContext private(sc: SparkContext) {
   def deploy[T](data: Iterable[T]): DataSet[T] = new DeployedDataSet(data)(sc)
 
   def textFile(file: java.io.File): DataSet[String] = new TextDataSet(file)(sc)
@@ -21,8 +23,39 @@ class OctopusContext(sc: SparkContext) {
 
 object OctopusContext {
 
+  private class ContextMapping() {
+    var sparkContext: SparkContext = null
+    var octopusContext: OctopusContext = null
+
+    def set(sc: SparkContext, oc: OctopusContext) = this.synchronized {
+      require(sc != null)
+      require(oc != null)
+      if (sparkContext != null) throw new IllegalStateException("Only one octopus context may be active at a time")
+      sparkContext = sc
+      octopusContext = oc
+    }
+
+    def getOctopusContext = this.synchronized {
+      octopusContext
+    }
+
+    def getSparkContext = this.synchronized {
+      sparkContext
+    }
+
+  }
+
+  private[octopus] val contextMapping = new ContextMapping()
+
   implicit class Make(sc: SparkContext) {
-    def getOctopusContext = new OctopusContext(sc)
+    def getOctopusContext = contextMapping.synchronized {
+      var oc = contextMapping.getOctopusContext
+      if (oc == null) {
+        oc = new OctopusContext(sc)
+        contextMapping.set(sc, oc)
+      }
+      oc
+    }
   }
 
 }

--- a/octopus/src/main/scala/octopus/Transformation.scala
+++ b/octopus/src/main/scala/octopus/Transformation.scala
@@ -1,4 +1,4 @@
-package main.scala.octopus
+package scala.octopus
 
 import scala.collection.{IterableView, mutable}
 
@@ -77,8 +77,4 @@ class FilterKeys[K, V](f: K => Boolean) extends Transformation[(K, V), (K, V)] {
 class MapValues[K, V, U](f: V => U) extends Transformation[(K, V), (K, U)] {
   override def transform(data: IterableView[(K, V), Iterable[_]]): IterableView[(K, U), Iterable[_]] =
     data.map { case (k, v) => (k, f(v)) }
-}
-
-object sandbox {
-  val t = Iterable(1, 2, 3).view
 }

--- a/octopus/src/test/scala/octopus/examples/ExamplePI.scala
+++ b/octopus/src/test/scala/octopus/examples/ExamplePI.scala
@@ -7,9 +7,9 @@ import scala.octopus.OctopusContext
 /**
  * Created by umizrahi on 25/02/2016.
  */
-object ExampleMonteCarlo {
+object ExamplePI {
 
-  /* test estimation of PI through monte carlo*/
+  /* test estimation of PI through monte carlo, by using the OctopusContext.executeJobs method*/
   def main(args: Array[String]) {
     import OctopusContext._
     val sc = new SparkContext(new SparkConf().setMaster("local[*]").setAppName("test_mc"))


### PR DESCRIPTION
Refactors OctopusContext and DataSet creation. OctopusContext is now unique to each SparkContext, and DataSets are now tied to their OctopusContext, allowing to keep track of a dataset id (will be used for caching).
